### PR TITLE
Feature: 添加暗语消息过期时间配置项

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ _✨ 通过森空岛查询游戏数据 ✨_
 |   `skland__github_token`    |  否  |    `""`     |       GitHub Token       |
 | `skland__check_res_update`  |  否  |   `False`   | 是否在启动时检查资源更新 |
 | `skland__background_source` |  否  | `"default"` |       背景图片来源       |
+|   `skland__argot_expire`    |  否  |    `300`    |  暗语消息过期时间（秒）  |
 
 > [!TIP]
 > 以上配置项均~~没什么用~~按需填写，GitHub Token 用于解决 fetch_file_list 接口到达免费调用上限，但不会有那么频繁的更新频率，99.98%的概率是用不上的。~~只是因为我开发测试的时候上限了，所以有了这项~~,

--- a/nonebot_plugin_skland/__init__.py
+++ b/nonebot_plugin_skland/__init__.py
@@ -38,9 +38,9 @@ from . import hook as hook
 from .render import render_ark_card
 from .exception import RequestException
 from .api import SklandAPI, SklandLoginAPI
-from .config import RESOURCE_ROUTES, Config
 from .download import GameResourceDownloader
 from .schemas import CRED, Topics, ArkSignResponse
+from .config import RESOURCE_ROUTES, Config, config
 from .db_handler import get_arknights_characters, get_arknights_character_by_uid, get_default_arknights_character
 from .utils import (
     get_background_image,
@@ -151,7 +151,9 @@ async def _(session: async_scoped_session, user_session: UserSession, target: Ma
         argot_seg = [Text(str(background)), Image(url=str(background))]
     else:
         argot_seg = Image(path=str(background))
-    msg = UniMessage.image(raw=image) + Argot("background", argot_seg, command="background", expired_at=300)
+    msg = UniMessage.image(raw=image) + Argot(
+        "background", argot_seg, command="background", expired_at=config.argot_expire
+    )
     await msg.send(reply_to=True)
     await session.commit()
 

--- a/nonebot_plugin_skland/config.py
+++ b/nonebot_plugin_skland/config.py
@@ -53,6 +53,8 @@ class ScopedConfig(BaseModel):
     """启动时检查资源更新"""
     background_source: Literal["default", "Lolicon", "random"] | CustomSource = "default"
     """背景图片来源"""
+    argot_expire: int = 300
+    """Argot 缓存过期时间"""
 
 
 class Config(BaseModel):


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为 Argot（秘密消息）缓存添加可配置的过期时间

新特性：
- 允许通过配置自定义 Argot 消息过期时间

增强功能：
- 引入了一个新的 Argot 消息过期时间配置选项

文档：
- 更新了 README 以记录新的配置选项

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable expiration time for Argot (secret message) cache

New Features:
- Allow customization of Argot message expiration time through configuration

Enhancements:
- Introduced a new configuration option for Argot message expiration

Documentation:
- Updated README to document the new configuration option

</details>