### PR TITLE
签到冲突修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ _✨ 通过森空岛查询游戏数据 ✨_
 |      `skland__github_token`       |  否  |    `""`     |       GitHub Token       |
 |    `skland__check_res_update`     |  否  |   `False`   | 是否在启动时检查资源更新 |
 |    `skland__background_source`    |  否  | `"default"` |       背景图片来源       |
-| `skland__rogue_background_source` |  否  |   `False`   |   肉鸽战绩背景图片来源   |
+| `skland__rogue_background_source` |  否  |   `"rogue"`   |   肉鸽战绩背景图片来源   |
 |      `skland__argot_expire`       |  否  |    `300`    |  暗语消息过期时间（秒）  |
 
 > [!TIP]
@@ -186,10 +186,10 @@ skland__background_source = '{"uri": "/imgs/image.jpg"}'
 |        `skland qrcode`         |   所有   |        无         |          扫码绑定森空岛账号           |
 |     `skland arksign sign`      |   所有   |        无         |         个人角色明日方舟签到          |
 | `skland arksign sign -u <uid>` |   所有   |       `uid`       |    指定绑定的个人角色 UID 进行签到    |
-|     `skland arksign --all`     | 超级用户 |        无         |      签到所有绑定到该 bot 的角色      |
+|     `skland arksign all`     | 超级用户 |        无         |      签到所有绑定到该 bot 的角色      |
 |    `skland arksign status`     |   所有   |        无         |       查询个人角色自动签到状态        |
 | `skland arksign status --all`  | 超级用户 |        无         | 查询所有绑定到该 bot 的角色的签到状态 |
-|     `skland arksign --all`     |   所有   |        无         |           签到所有绑定角色            |
+|     `skland arksign sign --all`     |   所有   |        无         |           签到所有绑定角色            |
 |      `skland char update`      |   所有   |        无         |        更新森空岛绑定角色信息         |
 |         `skland sync`          | 超级用户 |        无         |             本地资源更新              |
 |         `skland rogue`         |   所有   |  `@` \| `topic`   |             肉鸽战绩查询              |
@@ -211,7 +211,7 @@ skland__background_source = '{"uri": "/imgs/image.jpg"}'
 |   扫码绑定   |        `skland qrcode`        |
 | 明日方舟签到 |  `skland arksign sign --all`  |
 |   签到详情   |    `skland arksign status`    |
-|   全体签到   |    `skland arksign --all`     |
+|   全体签到   |    `skland arksign all`     |
 | 全体签到详情 | `skland arksign status --all` |
 |   角色更新   |     `skland char update`      |
 |   资源更新   |         `skland sync`         |

--- a/nonebot_plugin_skland/__init__.py
+++ b/nonebot_plugin_skland/__init__.py
@@ -115,7 +115,11 @@ skland = on_alconna(
                 Option("--all", help_text="查看所有绑定角色签到状态(仅超管可用)"),
                 help_text="查看绑定角色签到状态",
             ),
-            Option("--all", help_text="签到所有绑定角色(仅超管可用)"),
+            Subcommand(
+                "all",
+                help_text="签到所有绑定角色(仅超管可用)"
+            ),
+            #Option("--all", help_text="签到所有绑定角色(仅超管可用)"),
             help_text="明日方舟森空岛签到相关功能",
         ),
         Subcommand("char", Option("-u|--update|update"), help_text="更新绑定角色信息"),
@@ -157,7 +161,7 @@ skland.shortcut("森空岛绑定", {"command": "skland bind", "fuzzy": True, "pr
 skland.shortcut("扫码绑定", {"command": "skland qrcode", "fuzzy": False, "prefix": True})
 skland.shortcut("明日方舟签到", {"command": "skland arksign sign --all", "fuzzy": False, "prefix": True})
 skland.shortcut("签到详情", {"command": "skland arksign status", "fuzzy": False, "prefix": True})
-skland.shortcut("全体签到", {"command": "skland arksign --all", "fuzzy": False, "prefix": True})
+skland.shortcut("全体签到", {"command": "skland arksign all", "fuzzy": False, "prefix": True})
 skland.shortcut("全体签到详情", {"command": "skland arksign status --all", "fuzzy": False, "prefix": True})
 skland.shortcut(
     "萨卡兹肉鸽",

--- a/nonebot_plugin_skland/__init__.py
+++ b/nonebot_plugin_skland/__init__.py
@@ -116,7 +116,6 @@ skland = on_alconna(
                 help_text="查看绑定角色签到状态",
             ),
             Subcommand("all", help_text="签到所有绑定角色(仅超管可用)"),
-            # Option("--all", help_text="签到所有绑定角色(仅超管可用)"),
             help_text="明日方舟森空岛签到相关功能",
         ),
         Subcommand("char", Option("-u|--update|update"), help_text="更新绑定角色信息"),

--- a/nonebot_plugin_skland/__init__.py
+++ b/nonebot_plugin_skland/__init__.py
@@ -115,11 +115,8 @@ skland = on_alconna(
                 Option("--all", help_text="查看所有绑定角色签到状态(仅超管可用)"),
                 help_text="查看绑定角色签到状态",
             ),
-            Subcommand(
-                "all",
-                help_text="签到所有绑定角色(仅超管可用)"
-            ),
-            #Option("--all", help_text="签到所有绑定角色(仅超管可用)"),
+            Subcommand("all", help_text="签到所有绑定角色(仅超管可用)"),
+            # Option("--all", help_text="签到所有绑定角色(仅超管可用)"),
             help_text="明日方舟森空岛签到相关功能",
         ),
         Subcommand("char", Option("-u|--update|update"), help_text="更新绑定角色信息"),

--- a/nonebot_plugin_skland/extras.py
+++ b/nonebot_plugin_skland/extras.py
@@ -80,12 +80,12 @@ extra_data = {
         {
             "func": "全体签到",
             "trigger_method": "**超级用户**",
-            "trigger_condition": "**全体签到** | `skland arksign --all`",
+            "trigger_condition": "**全体签到** | `skland arksign all`",
             "brief_des": "签到所有绑定到bot的明日方舟账号。",
             "detail_des": (
                 "- **全体签到**\n\n"
                 "```bash\n"
-                "skland arksign --all\n"
+                "skland arksign all\n"
                 "```\n\n"
                 " **快捷指令** ：`全体签到`\n\n"
                 "签到所有绑定到bot的明日方舟账号。\n\n"


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将 arksign 的 "--all" 标志替换为专用的 "all" 子命令，以解决调用冲突并相应地更新相关快捷方式。

Bug 修复：
- 将已弃用的 "--all" 选项替换为 `arksign` 的 "all" 子命令，以修复冲突。
- 更新 "全体签到" 快捷方式以使用新的子命令语法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the arksign "--all" flag with a dedicated "all" subcommand to resolve invocation conflicts and update related shortcuts accordingly.

Bug Fixes:
- Replace the deprecated "--all" option with an "all" subcommand for `arksign` to fix conflicts.
- Update the "全体签到" shortcut to use the new subcommand syntax.

</details>