### PR TITLE
Feature: 小黑盒抽卡记录导入

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD033 MD036 MD041 MD046 -->
+<!-- markdownlint-disable MD028 MD033 MD036 MD041 MD046 -->
 <div align="center">
   <a href="https://v2.nonebot.dev/store"><img src="https://github.com/FrostN0v0/nonebot-plugin-template/blob/resources/NoneBotPlugin.svg" width="300"  alt="NoneBotPluginLogo"></a>
   <br>
@@ -196,6 +196,7 @@ skland__background_source = '{"uri": "/imgs/image.jpg"}'
 |        `skland rginfo`         |   所有   |     `战绩id`      |       根据 ID 查询最近战绩详情        |
 |       `skland rginfo -f`       |   所有   |     `战绩id`      |   根据 ID 查询森空岛收藏的战绩详情    |
 |         `skland gacha`         |   所有   |        无         |         查询明日方舟抽卡记录          |
+|        `skland import`         |   所有   |       `url`       |         导入明日方舟抽卡记录          |
 
 > [!NOTE]
 > Token 获取相关文档还没写~~才不是懒得写~~
@@ -203,6 +204,9 @@ skland__background_source = '{"uri": "/imgs/image.jpg"}'
 > 可以参考[`token获取`](https://docs.qq.com/doc/p/2f705965caafb3ef342d4a979811ff3960bb3c17)获取
 >
 > 本插件支持 cred 和 token 两种方式手动绑定，使用二维码绑定时会提供 token，请勿将 token 提供给不信任的 Bot 所有者
+
+> [!TIP]
+> 支持导入小黑盒记录的抽卡记录，请滑动至小黑盒抽卡分析页底部，点击`数据管理`导出数据并复制链接
 
 ### 🎯 快捷指令
 
@@ -224,6 +228,7 @@ skland__background_source = '{"uri": "/imgs/image.jpg"}'
 |   战绩详情   |        `skland rginfo`        |
 | 收藏战绩详情 |   `skland rginfo --favored`   |
 | 方舟抽卡记录 |        `skland gacha`         |
+| 导入抽卡记录 |        `skland import`        |
 
 #### 🪄 自定义快捷指令
 

--- a/nonebot_plugin_skland/__init__.py
+++ b/nonebot_plugin_skland/__init__.py
@@ -64,7 +64,9 @@ from .utils import (
     group_gacha_records,
     get_background_image,
     get_all_gacha_records,
+    heybox_data_to_record,
     get_characters_and_bind,
+    import_heybox_gacha_data,
     get_rogue_background_image,
     refresh_cred_token_if_needed,
     refresh_access_token_if_needed,
@@ -144,6 +146,9 @@ skland = on_alconna(
             help_text="查询单局肉鸽战绩详情",
         ),
         Subcommand("gacha", help_text="查询明日方舟抽卡记录"),
+        Subcommand(
+            "import", Args["url", str, Field(completion=lambda: "请输入抽卡记录导出链接")], help_text="导入抽卡记录"
+        ),
         namespace=alc_config.namespaces["skland"],
         meta=CommandMeta(
             description=__plugin_meta__.description,
@@ -698,3 +703,30 @@ async def _(user_session: UserSession, session: async_scoped_session):
     await UniMessage.image(raw=await render_gacha_history(gacha_data_grouped, character, user_info.status)).send()
     session.add_all(record_to_save)
     await session.commit()
+
+
+@skland.assign("import")
+async def _(url: Match[str], user_session: UserSession, session: async_scoped_session):
+    """导入明日方舟抽卡记录（开发中）"""
+    user = await session.get(SkUser, user_session.user_id)
+    if not user:
+        await UniMessage("未绑定 skland 账号").finish(at_sender=True)
+    character = await get_default_arknights_character(user, session)
+    if not character:
+        await UniMessage("未绑定 arknights 账号").finish(at_sender=True)
+    if url.available:
+        import_result = await import_heybox_gacha_data(url.result)
+        if str(import_result["info"]["uid"]) == character.uid:
+            records = heybox_data_to_record(import_result["data"], user.id, character.uid)
+            db_records = await select_all_gacha_records(user, character.uid, session)
+            existing_records_set = {(r.gacha_ts, r.pos) for r in db_records}
+            record_to_save: list[GachaRecord] = []
+            for record in records:
+                if (record.gacha_ts, record.pos) in existing_records_set:
+                    continue
+                record_to_save.append(record)
+            logger.debug(f"读取抽卡记录共 {len(records)} 条, 其中导入 {len(record_to_save)} 条新记录")
+            session.add_all(record_to_save)
+            await session.commit()
+        else:
+            await UniMessage("导入的抽卡记录与当前角色不匹配").finish(at_sender=True)

--- a/nonebot_plugin_skland/__init__.py
+++ b/nonebot_plugin_skland/__init__.py
@@ -698,7 +698,9 @@ async def _(user_session: UserSession, session: async_scoped_session):
             continue
         record_to_save.append(record)
 
-    gacha_data_grouped = group_gacha_records(gacha_record_list)
+    all_gacha_records = records + record_to_save
+
+    gacha_data_grouped = group_gacha_records(all_gacha_records)
     user_info = await get_user_info(user, character.uid)
     await UniMessage.image(raw=await render_gacha_history(gacha_data_grouped, character, user_info.status)).send()
     session.add_all(record_to_save)
@@ -727,6 +729,9 @@ async def _(url: Match[str], user_session: UserSession, session: async_scoped_se
                 record_to_save.append(record)
             logger.debug(f"读取抽卡记录共 {len(records)} 条, 其中导入 {len(record_to_save)} 条新记录")
             session.add_all(record_to_save)
+            await UniMessage(f"导入成功，读取抽卡记录共 {len(records)} 条, 共导入 {len(record_to_save)} 条新记录").send(
+                at_sender=True
+            )
             await session.commit()
         else:
             await UniMessage("导入的抽卡记录与当前角色不匹配").finish(at_sender=True)

--- a/nonebot_plugin_skland/extras.py
+++ b/nonebot_plugin_skland/extras.py
@@ -157,6 +157,21 @@ extra_data = {
             ),
         },
         {
+            "func": "导入抽卡记录",
+            "trigger_method": "**已绑定用户**",
+            "trigger_condition": "**导入抽卡记录** | `skland import`",
+            "brief_des": "导入小黑盒明日方舟抽卡记录。",
+            "detail_des": (
+                "- **导入抽卡记录**\n\n"
+                "```bash\n"
+                "skland import <url>\n"
+                "```\n\n"
+                " **快捷指令** ：`导入抽卡记录`\n\n"
+                "支持导入小黑盒记录的抽卡记录\n"
+                "请滑动至小黑盒抽卡分析页底部，点击`数据管理`导出数据并复制链接"
+            ),
+        },
+        {
             "func": "角色更新",
             "trigger_method": "**已绑定用户**",
             "trigger_condition": "**角色更新** | `skland char update`",

--- a/nonebot_plugin_skland/schemas/__init__.py
+++ b/nonebot_plugin_skland/schemas/__init__.py
@@ -10,9 +10,10 @@ from .gacha import GachaPull as GachaPull
 from .rogue import RogueData as RogueData
 from .gacha import GachaGroup as GachaGroup
 from .gacha import GachaTable as GachaTable
-from .gacha import GachaDetails as GachaDetails
+from .game_data import CharTable as CharTable
 from .ark_models import AssistChar as AssistChar
 from .gacha import GachaResponse as GachaResponse
+from .game_data import GachaDetails as GachaDetails
 from .ark_sign import ArkSignResult as ArkSignResult
 from .ark_sign import ArkSignResponse as ArkSignResponse
 from .gacha import GroupedGachaRecord as GroupedGachaRecord

--- a/nonebot_plugin_skland/schemas/gacha.py
+++ b/nonebot_plugin_skland/schemas/gacha.py
@@ -228,34 +228,3 @@ class GroupedGachaRecord(BaseModel):
     def doub_six_avg(self) -> float:
         total = self.doub_total_six
         return round(self._sum_by("bare_six_consume", "doub") / total, 1) if total else 0.0
-
-
-class PerChar(BaseModel):
-    rarityRank: int
-    charIdList: list[str]
-
-
-class UpCharInfo(BaseModel):
-    perCharList: list[PerChar]
-
-
-class AvailCharInfo(BaseModel):
-    perAvailList: list[PerChar]
-
-
-class GachaDetailInfo(BaseModel):
-    upCharInfo: UpCharInfo | None = None
-    availCharInfo: AvailCharInfo | None = None
-    """UP角色信息"""
-
-
-class GachaDetail(BaseModel):
-    detailInfo: GachaDetailInfo
-    """卡池详情"""
-
-
-class GachaDetails(BaseModel):
-    """抽卡详情"""
-
-    gachaPoolDetail: GachaDetail
-    gachaPoolId: str

--- a/nonebot_plugin_skland/schemas/game_data.py
+++ b/nonebot_plugin_skland/schemas/game_data.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel
+
+
+class PerChar(BaseModel):
+    rarityRank: int
+    charIdList: list[str]
+
+
+class UpCharInfo(BaseModel):
+    perCharList: list[PerChar]
+
+
+class AvailCharInfo(BaseModel):
+    perAvailList: list[PerChar]
+
+
+class GachaDetailInfo(BaseModel):
+    upCharInfo: UpCharInfo | None = None
+    availCharInfo: AvailCharInfo | None = None
+    """UP角色信息"""
+
+
+class GachaDetail(BaseModel):
+    detailInfo: GachaDetailInfo
+    """卡池详情"""
+
+
+class GachaDetails(BaseModel):
+    """抽卡详情"""
+
+    gachaPoolDetail: GachaDetail
+    gachaPoolId: str
+
+
+class CharTable(BaseModel):
+    """角色信息表"""
+
+    char_id: str = ""
+    """角色ID"""
+    name: str
+    """角色名称"""

--- a/nonebot_plugin_skland/utils.py
+++ b/nonebot_plugin_skland/utils.py
@@ -335,10 +335,10 @@ async def import_heybox_gacha_data(url: str) -> dict:
 
 def get_char_id_by_char_name(char_name: str) -> str:
     """通过角色名称获取角色ID"""
-    for char in gacha_table_data.character_table:
-        if char.name == char_name:
-            return char.char_id
-    return "char_601_cguard"
+    return next(
+        (char.char_id for char in gacha_table_data.character_table if char.name == char_name),
+        "char_601_cguard",
+    )
 
 
 def get_pool_id(pool_name: str, gacha_ts: int) -> str:
@@ -371,23 +371,18 @@ def heybox_data_to_record(data: dict, uid: int, char_uid: str) -> list[GachaReco
         if pool_id == "NORM_1_0_1":
             pool_name = "未知寻访"
         for index, char in enumerate(gacha_data["c"]):
-            char_name = char[0]
-            char_id = get_char_id_by_char_name(char[0])
-            rarity = char[1]
-            is_new = char[2]
-            pos = index
             records.append(
                 GachaRecord(
                     uid=uid,
                     char_uid=char_uid,
                     pool_id=pool_id,
                     pool_name=pool_name,
-                    char_id=char_id,
-                    char_name=char_name,
-                    rarity=rarity,
-                    is_new=is_new,
+                    char_id=get_char_id_by_char_name(char[0]),
+                    char_name=char[0],
+                    rarity=char[1],
+                    is_new=char[2],
                     gacha_ts=int(gacha_ts),
-                    pos=pos,
+                    pos=index,
                 )
             )
     return records

--- a/nonebot_plugin_skland/utils.py
+++ b/nonebot_plugin_skland/utils.py
@@ -341,11 +341,24 @@ def get_char_id_by_char_name(char_name: str) -> str:
     return "char_601_cguard"
 
 
-def get_pool_id_by_pool_name(pool_name: str) -> str:
+def get_pool_id(pool_name: str, gacha_ts: int) -> str:
     """通过卡池名称获取卡池ID"""
+    special_pools = {
+        "中坚寻访": [4, 10],
+        "标准寻访": [0, 9],
+        "中坚甄选": [6],
+        "联合行动": [0],
+        "常驻标准寻访": [0],
+    }
     for gacha_pool in gacha_table_data.gacha_table:
-        if gacha_pool.gachaPoolName == pool_name:
+        if gacha_pool.gachaPoolName == pool_name and gacha_pool.openTime <= gacha_ts <= gacha_pool.endTime:
             return gacha_pool.gachaPoolId
+        elif pool_name in special_pools:
+            if (
+                gacha_pool.gachaRuleType in special_pools[pool_name]
+                and gacha_pool.openTime <= gacha_ts <= gacha_pool.endTime
+            ):
+                return gacha_pool.gachaPoolId
     return "NORM_1_0_1"
 
 
@@ -354,7 +367,7 @@ def heybox_data_to_record(data: dict, uid: int, char_uid: str) -> list[GachaReco
     records: list[GachaRecord] = []
     for gacha_ts, gacha_data in data.items():
         pool_name = gacha_data["p"]
-        pool_id = get_pool_id_by_pool_name(pool_name)
+        pool_id = get_pool_id(pool_name, int(gacha_ts))
         if pool_id == "NORM_1_0_1":
             pool_name = "未知寻访"
         for index, char in enumerate(gacha_data["c"]):


### PR DESCRIPTION
```chinese
## Sourcery 总结

添加 Heybox 抽卡记录导入功能，在加载抽卡表的同时加载角色元数据，并重构相关模式

新功能：
- 实现 'gacha import' 子命令，用于导入 Heybox 导出的抽卡记录
- 添加 `import_heybox_gacha_data` 工具，用于获取 Heybox JSON 导出数据
- 添加 `heybox_data_to_record` 工具，用于将 Heybox 数据转换为内部 GachaRecord 项

改进：
- 规范化抽卡时间戳，从毫秒转换为秒
- 在游戏数据路由中包含 `character_table.json`，并加载角色元数据以实现名称到 ID 的映射
- 重构游戏数据模式，将 GachaDetail 模型移动到专门的 `game_data` 模块
```

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

实现 Heybox 抽卡记录导入功能并重构相关数据处理

新功能：
- 添加 "skland import" 子命令以导入 Heybox 导出的抽卡记录
- 引入 import_heybox_gacha_data 和 heybox_data_to_record 工具函数，用于获取 Heybox JSON 并将其转换为内部 GachaRecord 项

改进：
- 在记录加载期间将抽卡时间戳从毫秒标准化为秒
- 从 character_table.json 加载并缓存角色元数据，用于名称到 ID 的映射
- 重构游戏数据模式，将 GachaDetail 模型移至专用的 game_data 模块
- 使用新的 check_user_character 辅助函数统一用户和角色验证逻辑

文档：
- 更新 README 和 extras 文档，以包含新的导入命令

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement Heybox gacha record import feature and refactor related data handling

New Features:
- Add "skland import" subcommand to import Heybox-exported gacha records
- Introduce import_heybox_gacha_data and heybox_data_to_record utilities to fetch and convert Heybox JSON into internal GachaRecord items

Enhancements:
- Normalize gacha timestamps from milliseconds to seconds during record loading
- Load and cache character metadata from character_table.json for name-to-ID mapping
- Refactor game data schemas by moving GachaDetail models into a dedicated game_data module
- Unify user and character validation logic with a new check_user_character helper

Documentation:
- Update README and extras documentation to include the new import command

</details>

</details>