### PR TITLE
🐛 抽卡记录 char_pk_id 字段

### DIFF
--- a/nonebot_plugin_skland/__init__.py
+++ b/nonebot_plugin_skland/__init__.py
@@ -669,6 +669,7 @@ async def _(user_session: UserSession, session: async_scoped_session):
     for gacha_record in all_gacha_records_flat:
         record = GachaRecord(
             uid=user.id,
+            char_pk_id=character.id,
             char_uid=character.uid,
             pool_id=gacha_record.poolId,
             pool_name=gacha_record.poolName,
@@ -702,7 +703,7 @@ async def _(url: Match[str], user_session: UserSession, session: async_scoped_se
     if url.available:
         import_result = await import_heybox_gacha_data(url.result)
         if str(import_result["info"]["uid"]) == character.uid:
-            records = heybox_data_to_record(import_result["data"], user.id, character.uid)
+            records = heybox_data_to_record(import_result["data"], user.id, character.id, character.uid)
             db_records = await select_all_gacha_records(user, character.uid, session)
             existing_records_set = {(r.gacha_ts, r.pos) for r in db_records}
             record_to_save: list[GachaRecord] = []

--- a/nonebot_plugin_skland/utils.py
+++ b/nonebot_plugin_skland/utils.py
@@ -368,7 +368,7 @@ def get_pool_id(pool_name: str, gacha_ts: int) -> str:
     return "NORM_1_0_1"
 
 
-def heybox_data_to_record(data: dict, uid: int, char_uid: str) -> list[GachaRecord]:
+def heybox_data_to_record(data: dict, uid: int, char_id: int, char_uid: str) -> list[GachaRecord]:
     """将Heybox导出的抽卡记录转换为GachaRecord列表"""
     records: list[GachaRecord] = []
     for gacha_ts, gacha_data in data.items():
@@ -380,6 +380,7 @@ def heybox_data_to_record(data: dict, uid: int, char_uid: str) -> list[GachaReco
             records.append(
                 GachaRecord(
                     uid=uid,
+                    char_pk_id=char_id,
                     char_uid=char_uid,
                     pool_id=pool_id,
                     pool_name=pool_name,


### PR DESCRIPTION
Issue: #36 
related: #37

## Sourcery 总结

在扭蛋记录创建和更新相关的函数签名和调用中，包含缺失的 char_pk_id (角色主键 ID)

Bug 修复:
- 在用户信息检索和处理后的 heybox 数据中，为 `GachaRecord` 实例化添加 `char_pk_id` 字段
- 更新 `heybox_data_to_record` 的函数签名和调用，以接受并赋值 `char_pk_id`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include the missing char_pk_id (character primary key ID) in gacha record creation and update related function signatures and calls

Bug Fixes:
- Add char_pk_id field to GachaRecord instantiation in user info retrieval and processed heybox data
- Update heybox_data_to_record signature and invocation to accept and assign char_pk_id

</details>