### PR TITLE
Fix: 为 model_validator 添加缺失的 @classmethod 装饰器

### DIFF
--- a/nonebot_plugin_skland/download.py
+++ b/nonebot_plugin_skland/download.py
@@ -31,6 +31,7 @@ class File(BaseModel):
     download_url: str
 
     @model_validator(mode="before")
+    @classmethod
     def modify_download_url(cls, values):
         from .config import config
 

--- a/nonebot_plugin_skland/schemas/ark_card.py
+++ b/nonebot_plugin_skland/schemas/ark_card.py
@@ -63,6 +63,7 @@ class ArkCard(BaseModel):
         return ""
 
     @model_validator(mode="after")
+    @classmethod
     def inject_uniequip_uris(cls, values) -> Any:
         if isinstance(values, dict):
             assist_chars = values.get("assistChars", [])
@@ -85,6 +86,7 @@ class ArkCard(BaseModel):
             return values
 
     @model_validator(mode="after")
+    @classmethod
     def inject_manufacture_stoke(cls, values) -> Any:
         if isinstance(values, dict):
             building = values.get("building")

--- a/nonebot_plugin_skland/schemas/gacha.py
+++ b/nonebot_plugin_skland/schemas/gacha.py
@@ -86,6 +86,7 @@ class GachaGroup(BaseModel):
     pulls: list[GachaPull]
 
     @model_validator(mode="before")
+    @classmethod
     def sort_pulls(cls, values) -> Any:
         if "pulls" in values:
             values["pulls"] = sorted(values["pulls"], key=lambda x: x.pos, reverse=True)
@@ -101,6 +102,7 @@ class GachaPool(GachaTable):
     """该卡池的抽卡记录"""
 
     @model_validator(mode="before")
+    @classmethod
     def sort_records(cls, values) -> Any:
         if "records" in values:
             values["records"] = sorted(values["records"], key=lambda x: x.gacha_ts, reverse=True)
@@ -147,6 +149,7 @@ class GroupedGachaRecord(BaseModel):
     pools: list[GachaPool]
 
     @model_validator(mode="before")
+    @classmethod
     def sort_pools(cls, values) -> Any:
         if "pools" in values:
             values["pools"] = sorted(values["pools"], key=lambda x: x.openTime, reverse=True)


### PR DESCRIPTION
不加 `@classmethod` 的写法在 `pydantic>=2.12` 出现错误

```python
    @model_validator(mode="after")
    def validate_sth(cls, values):
        ...
```

- `pydantic>=2,<2.12`: cls 为模型类，values 为模型实例
- `pydantic>=2.12`: cls 为模型实例，values 为 `ValidationInfo` 对象

PR 修改：

```diff
    @model_validator(mode="after")
+   @classmethod
    def validate_sth(cls, values):
        ...
```

Tested on: pydantic `1.10.24`/`2.11.10`/`2.12.0`

> btw, [pydantic v2 文档](https://docs.pydantic.dev/latest/concepts/validators/#model-validators) 在 `mode="after"` 用的是实例方法而非类方法
> 但 pydantic v1 似乎需要 (cls, values): `pydantic.errors.ConfigError: Invalid signature for root validator inject_uniequip_uris: (self) -> Any, "self" not permitted as first argument, should be: (cls, values).`

## Sourcery 总结

Bug 修复:
- 在 gacha、ark_card 和 download 模块中，为使用 `@model_validator` 的方法添加 `@classmethod` 装饰器，以防止 Pydantic >=2.12 中的签名错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add @classmethod decorator to methods using @model_validator in gacha, ark_card, and download modules to prevent signature errors in Pydantic >=2.12

</details>