### PR TITLE
Fix: 基建未开放情况下部分数据可为 None

### DIFF
--- a/nonebot_plugin_skland/schemas/ark_models/building.py
+++ b/nonebot_plugin_skland/schemas/ark_models/building.py
@@ -41,9 +41,9 @@ class Building(BaseModel):
     manufactures: list[Manufacture]
     tradings: list[Trading]
     dormitories: list[Dormitory]
-    meeting: Meeting
-    hire: Hire
-    training: Training
+    meeting: Meeting | None = None
+    hire: Hire | None = None
+    training: Training | None = None
     labor: Labor
     furniture: Furniture
     control: Control


### PR DESCRIPTION
resolve #50

## Summary by Sourcery

错误修复：
- 处理可能缺少会议、招聘和培训信息的情况，而不是始终将它们作为必填项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle cases where building meeting, hire, and training information may be missing instead of always requiring them.

</details>