### PR TITLE
🐛 修复醚质计数错误

### DIFF
--- a/nonebot_plugin_skland/render.py
+++ b/nonebot_plugin_skland/render.py
@@ -174,7 +174,8 @@ async def render_ef_card(props: EndfieldCard, bg: str | Url, show_all: bool = Fa
 
     # 汇总所有据点的 trchestCount（储藏箱总数）
     total_trchest_count = sum(collection.trchestCount for domain in props.domain for collection in domain.collections)
-
+    # 汇总所有据点的 puzzleCount（醚质总数）
+    total_puzzle_count = sum(collection.puzzleCount for domain in props.domain for collection in domain.collections)
     # 计算理智恢复剩余时间
     current_ts = float(props.currentTs) if props.currentTs else datetime.now().timestamp()
     max_ts = float(props.dungeon.maxTs) if props.dungeon.maxTs else current_ts
@@ -208,6 +209,7 @@ async def render_ef_card(props: EndfieldCard, bg: str | Url, show_all: bool = Fa
             "domain": props.domain,
             "control_center_level": control_center_level,
             "total_trchest_count": total_trchest_count,
+            "total_puzzle_count": total_puzzle_count,
             "stamina_remaining_seconds": stamina_remaining_seconds,
             "stamina_percent": stamina_percent,
         },

--- a/nonebot_plugin_skland/resources/templates/endfield_card.html.jinja2
+++ b/nonebot_plugin_skland/resources/templates/endfield_card.html.jinja2
@@ -112,7 +112,7 @@
                 <span class="text-[#080808]/60 font-[Bender] font-bold text-sm">总控中枢等级</span>
               </div>
               <div class="w-25 h-15 bg-[#E6E6E6]/60 rounded-sm card-shadow flex flex-col items-center justify-center">
-                <span class="text-[#080808]/80 font-[Bender] font-bold">{{ base.docNum }}</span>
+                <span class="text-[#080808]/80 font-[Bender] font-bold">{{ total_puzzle_count }}</span>
                 <span class="text-[#080808]/60 font-[Bender] font-bold">醚质</span>
               </div>
               <div class="w-25 h-15 bg-[#E6E6E6]/60 rounded-sm card-shadow flex flex-col items-center justify-center">


### PR DESCRIPTION
resolve #72

## Summary by Sourcery

Bug Fixes:
- 通过在所有域和集合中聚合 `puzzleCount`，而不是使用不相关的 `docNum` 字段，修正 Endfield 卡片上以太（谜题）显示错误的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the ether (puzzle) display on the Endfield card by aggregating puzzleCount across all domains and collections instead of using an unrelated docNum field.

</details>