### PR TITLE
Fix: 修正 render_ef_card 中角色过滤逻辑

### DIFF
--- a/nonebot_plugin_skland/render.py
+++ b/nonebot_plugin_skland/render.py
@@ -202,7 +202,7 @@ async def render_ef_card(props: EndfieldCard, bg: str | Url, show_all: bool = Fa
         filtered_chars = props.chars
     else:
         # 按 config.charIds 过滤并保持顺序
-        char_map = {char.id: char for char in props.chars}
+        char_map = {char.charData.id: char for char in props.chars}
         filtered_chars = [char_map[cid] for cid in props.config.charIds if cid in char_map]
 
     # 提取总控中枢等级


### PR DESCRIPTION
管理员的 `char.id` 和 `char.charData.id` 不一样
`props.config.charIds` 里用的应该是 `charData.id`

## 由 Sourcery 提供的摘要

错误修复：
- 修正 Endfield 卡片渲染中的角色查找逻辑，使配置中的 `charIds` 与 `charData.id` 进行匹配，从而确保管理员角色能够被正确过滤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct character lookup in Endfield card rendering so configuration charIds are matched against charData.id, ensuring administrator characters are filtered correctly.

</details>