### PR TITLE
Feature: 适配终末地联合寻访卡池

### DIFF
--- a/nonebot_plugin_skland/commands/endfield/gacha.py
+++ b/nonebot_plugin_skland/commands/endfield/gacha.py
@@ -27,6 +27,7 @@ EF_CHAR_POOL_TYPES: list[EndfieldCharPoolType] = [
     EndfieldPoolType.STANDARD,
     EndfieldPoolType.SPECIAL,
     EndfieldPoolType.BEGINNER,
+    EndfieldPoolType.JOINT,
 ]
 
 
@@ -120,22 +121,20 @@ async def ef_gacha_history_handler(
     # ── 分组 ──
     gacha_data = group_ef_gacha_records(all_gacha_records)
 
-    # 获取每个 SPECIAL 卡池的 UP 角色信息
-    for pool in gacha_data.special_pools + gacha_data.weapon_pools:
-        # 优先从本地卡池数据查询 UP 信息
+    # 获取每个有UP信息卡池的 UP 角色/武器信息
+    for pool in gacha_data.special_pools + gacha_data.joint_pools + gacha_data.weapon_pools:
         local_pool = ef_gacha_pool_data.get_pool(pool.pool_id)
         if local_pool:
             pool.up_six_chars = local_pool.up_six_char_ids
             pool.up6_img = local_pool.up6_image or local_pool.rotate_image
-            pool.up6_name = local_pool.up6_name
+            pool.up6_name = local_pool.up_six_display_name
             logger.debug(f"卡池 {pool.pool_name}({pool.pool_id}) UP六星(本地): {pool.up_six_chars}")
         else:
-            # 本地无数据时 fallback 到实时 API
             try:
                 content = await SklandAPI.get_ef_gacha_content(pool.pool_id, character.channel_master_id)
                 pool.up_six_chars = content.pool.up_six_char_ids
                 pool.up6_img = content.pool.up6_image or content.pool.rotate_image
-                pool.up6_name = content.pool.up6_name
+                pool.up6_name = content.pool.up_six_display_name
                 logger.debug(f"卡池 {pool.pool_name}({pool.pool_id}) UP六星(API): {pool.up_six_chars}")
             except Exception as e:
                 logger.warning(f"获取卡池 {pool.pool_name} UP信息失败: {e}")

--- a/nonebot_plugin_skland/render.py
+++ b/nonebot_plugin_skland/render.py
@@ -167,8 +167,17 @@ async def render_gacha_history(
     )
 
 
+EF_GACHA_BASE_MIN_WIDTH = 680
+EF_GACHA_JOINT_MIN_WIDTH = 900
+EF_GACHA_VIEWPORT_PADDING = 120
+
+
+def get_ef_gacha_min_width(props: EfGroupedGachaRecord) -> int:
+    return EF_GACHA_JOINT_MIN_WIDTH if props.joint_pools else EF_GACHA_BASE_MIN_WIDTH
+
+
 def get_ef_gacha_viewport_width(props: EfGroupedGachaRecord) -> int:
-    return 1020 if props.joint_pools else 800
+    return get_ef_gacha_min_width(props) + EF_GACHA_VIEWPORT_PADDING
 
 
 async def render_ef_gacha_history(
@@ -185,6 +194,7 @@ async def render_ef_gacha_history(
             "avatar_url": player.avatarUrl,
             "record": props,
             "character": char,
+            "ef_gacha_min_width": get_ef_gacha_min_width(props),
             "start_index": begin,
             "end_index": limit,
         },

--- a/nonebot_plugin_skland/render.py
+++ b/nonebot_plugin_skland/render.py
@@ -167,6 +167,10 @@ async def render_gacha_history(
     )
 
 
+def get_ef_gacha_viewport_width(props: EfGroupedGachaRecord) -> int:
+    return 1020 if props.joint_pools else 800
+
+
 async def render_ef_gacha_history(
     props: EfGroupedGachaRecord,
     player: PlayerBase,
@@ -189,7 +193,7 @@ async def render_ef_gacha_history(
             "ef_charId_to_avatarUrl": ef_charId_to_avatarUrl,
         },
         pages={
-            "viewport": {"width": 800, "height": 1},
+            "viewport": {"width": get_ef_gacha_viewport_width(props), "height": 1},
             "base_url": f"file://{TEMPLATES_DIR}",
         },
         device_scale_factor=1.5,

--- a/nonebot_plugin_skland/resources/templates/ef_gacha.html.jinja2
+++ b/nonebot_plugin_skland/resources/templates/ef_gacha.html.jinja2
@@ -12,7 +12,7 @@
 </head>
 
 <body>
-    <div class="relative w-auto h-auto flex flex-col p-4 gap-4 bg-[#1a1a2e]" style="min-width: {{ 900 if record.joint_pools else 680 }}px;">
+    <div class="relative w-auto h-auto flex flex-col p-4 gap-4 bg-[#1a1a2e]" style="min-width: {{ ef_gacha_min_width }}px;">
 
         {# ═══════════════════ 上半部分：账号信息 + 统计数据 ═══════════════════ #}
 

--- a/nonebot_plugin_skland/resources/templates/ef_gacha.html.jinja2
+++ b/nonebot_plugin_skland/resources/templates/ef_gacha.html.jinja2
@@ -12,7 +12,7 @@
 </head>
 
 <body>
-    <div class="relative w-auto h-auto flex flex-col p-4 gap-4 bg-[#1a1a2e]" style="min-width: 680px;">
+    <div class="relative w-auto h-auto flex flex-col p-4 gap-4 bg-[#1a1a2e]" style="min-width: {{ 900 if record.joint_pools else 680 }}px;">
 
         {# ═══════════════════ 上半部分：账号信息 + 统计数据 ═══════════════════ #}
 
@@ -117,6 +117,30 @@
                     </div>
                 </div>
 
+                {# 联合寻访统计 #}
+                {% if record.joint_pools %}
+                <div class="flex-1 bg-[#2a2a3e] rounded-xl p-3 gacha-info-shadow flex flex-col justify-between">
+                    <div class="flex items-center gap-1.5 mb-1">
+                        <div class="w-1 h-4 rounded-full bg-[#c084fc]"></div>
+                        <span class="text-white font-[Akrobat] font-bold text-sm">联合寻访</span>
+                    </div>
+                    <div class="text-center mb-1">
+                        <span class="text-white font-[Akrobat] font-bold text-2xl">{{ record.joint_total_pulls }}</span>
+                        <span class="text-white/60 text-sm font-[Akrobat]">抽</span>
+                    </div>
+                    <div class="flex justify-around text-center gap-1">
+                        <div class="flex flex-col">
+                            <span class="text-[#FFCC00] font-[Akrobat] font-bold text-base">{{ record.joint_total_six }}</span>
+                            <span class="text-white/40 text-[10px]">6★</span>
+                        </div>
+                        <div class="flex flex-col">
+                            <span class="text-white font-[Akrobat] font-bold text-base">{{ "%.1f"|format(record.joint_six_avg) if record.joint_total_six > 0 else "-" }}</span>
+                            <span class="text-white/40 text-[10px]">6★平均</span>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
+
                 {# 常驻池统计 #}
                 <div class="flex-1 bg-[#2a2a3e] rounded-xl p-3 gacha-info-shadow flex flex-col justify-between">
                     <div class="flex items-center gap-1.5 mb-1">
@@ -214,6 +238,7 @@
         <div class="flex flex-row gap-3 items-start">
             {{ ef_pool_column(record.special_pools, "限定池", "#e17055", gacha_data=record, visible_pool_ids=visible_ids) }}
             {{ ef_pool_column(record.weapon_pools, "武器池", "#fdcb6e", gacha_data=record, visible_pool_ids=visible_ids) }}
+            {{ ef_pool_column(record.joint_pools, "联合寻访", "#c084fc", gacha_data=record, visible_pool_ids=visible_ids) }}
 
             {# 新手池 + 常驻池合并列 #}
             {% if visible_ids is not none %}

--- a/nonebot_plugin_skland/resources/templates/ef_gacha_macros.html.jinja2
+++ b/nonebot_plugin_skland/resources/templates/ef_gacha_macros.html.jinja2
@@ -1,6 +1,7 @@
 {# 终末地单卡池渲染宏 #}
 {% macro ef_pool_card(pool, pool_label, pool_color, gacha_data=none) %}
 {% set stats = namespace(pity_count=0, five_stars=[]) %}
+{% set show_spook = pool.show_spook_stats %}
 
 <div class="flex flex-col gap-1.5 w-full rounded-xl p-2 border border-white/10"
      style="background-color: #24243e; box-shadow: 0 4px 20px rgba(0,0,0,0.35);">
@@ -20,8 +21,13 @@
             <div class="flex items-center justify-between">
                 <div class="flex flex-col">
                     <span class="text-white font-[Akrobat] font-bold text-xs truncate max-w-28">{{ pool.pool_name }}</span>
-                    {% if pool.up6_name %}
-                    <span class="text-[#FFCC00] text-[9px] font-[Akrobat] truncate max-w-28">UP: {{ pool.up6_name }}</span>
+                    {% if pool.up_six_chars %}
+                    <div class="flex items-center gap-0.5 mt-0.5 max-w-28 overflow-hidden">
+                        <span class="text-[#FFCC00] text-[8px] font-[Akrobat] font-bold flex-shrink-0">UP</span>
+                        {% for up_char_id in pool.up_six_chars %}
+                        <img src="{{ up_char_id | ef_charId_to_avatarUrl }}" class="w-4 h-4 rounded-sm bg-[#3a3a4e] object-cover flex-shrink-0" />
+                        {% endfor %}
+                    </div>
                     {% endif %}
                 </div>
                 <div class="flex items-center gap-0.5 bg-[{{ pool_color }}]/90 rounded-md px-1.5 py-0.5">
@@ -36,9 +42,9 @@
             <div class="flex justify-between text-center gap-1">
                 <div class="flex flex-col items-center flex-1">
                     <span class="font-[Akrobat] font-bold text-sm">
-                        <span class="text-[#FFCC00]">{{ pool.total_six_stars }}</span>{% if pool.up_six_chars %}<span class="text-white/30">/</span><span class="text-[#C04855]">{{ pool.total_six_spook }}</span>{% endif %}
+                        <span class="text-[#FFCC00]">{{ pool.total_six_stars }}</span>{% if show_spook %}<span class="text-white/30">/</span><span class="text-[#C04855]">{{ pool.total_six_spook }}</span>{% endif %}
                     </span>
-                    <span class="text-white/50 text-[9px]">{% if pool.up_six_chars %}6★/歪{% else %}6★{% endif %}</span>
+                    <span class="text-white/50 text-[9px]">{% if show_spook %}6★/歪{% else %}6★{% endif %}</span>
                 </div>
                 <div class="flex flex-col items-center flex-1">
                     <span class="text-white font-[Akrobat] font-bold text-sm">{{ pool.pity_count }}</span>
@@ -87,7 +93,7 @@
                 <div class="flex flex-col flex-1 gap-0.5 min-w-0">
                     <div class="flex items-center gap-1">
                         <span class="text-white font-[Akrobat] font-bold text-xs truncate">{{ pull.item_name }}</span>
-                        {% if pool.up_six_chars and pull.item_id not in pool.up_six_chars %}
+                        {% if show_spook and pull.item_id not in pool.up_six_chars %}
                         <span class="text-[7px] text-white bg-[#C04855] rounded-xs px-0.5">歪</span>
                         {% endif %}
                         {% if pool.up_six_chars and pull.item_id in pool.up_six_chars %}
@@ -193,7 +199,7 @@
                     {# 角色名 + 标记，压在进度条上方 #}
                     <div class="flex items-center gap-1">
                         <span class="text-white font-[Akrobat] font-bold text-xs truncate">{{ pull.item_name }}</span>
-                        {% if pool.up_six_chars and pull.item_id not in pool.up_six_chars %}
+                        {% if show_spook and pull.item_id not in pool.up_six_chars %}
                         <span class="text-[7px] text-white bg-[#C04855] rounded-xs px-0.5">歪</span>
                         {% endif %}
                         {% if pool.up_six_chars and pull.item_id in pool.up_six_chars %}

--- a/nonebot_plugin_skland/schemas/endfield/gacha/base.py
+++ b/nonebot_plugin_skland/schemas/endfield/gacha/base.py
@@ -13,6 +13,7 @@ class EndfieldPoolType(Enum):
     STANDARD = "E_CharacterGachaPoolType_Standard"
     SPECIAL = "E_CharacterGachaPoolType_Special"
     BEGINNER = "E_CharacterGachaPoolType_Beginner"
+    JOINT = "E_CharacterGachaPoolType_Joint"
     WEAPON = ""
 
 
@@ -20,6 +21,7 @@ EndfieldCharPoolType = Literal[
     EndfieldPoolType.STANDARD,
     EndfieldPoolType.SPECIAL,
     EndfieldPoolType.BEGINNER,
+    EndfieldPoolType.JOINT,
 ]
 EndfieldWeaponPoolType = Literal[EndfieldPoolType.WEAPON]
 
@@ -223,15 +225,19 @@ class EfGachaContentPool(BaseModel):
 
     @property
     def up_six_char_ids(self) -> list[str]:
-        """获取该卡池中UP六星角色的ID列表
-
-        仅返回 up6_name 对应的角色ID（当期真正的UP角色），
-        rotate_list 中的其他轮换角色不算UP（抽到算歪）。
-        all 列表中 rarity 为 1-indexed（6=6★）。
-        """
+        """获取该卡池中UP六星角色的ID列表"""
+        if self.pool_type == "extra":
+            return [c.id for c in self.all if c.rarity == 6]
         if self.up6_name:
             return [c.id for c in self.all if c.rarity == 6 and c.name == self.up6_name]
         return []
+
+    @property
+    def up_six_display_name(self) -> str:
+        """获取渲染用UP六星名称"""
+        if self.pool_type == "extra":
+            return " / ".join(c.name for c in self.all if c.rarity == 6)
+        return self.up6_name
 
 
 class EfGachaContentResponse(BaseModel):

--- a/nonebot_plugin_skland/schemas/endfield/gacha/pool.py
+++ b/nonebot_plugin_skland/schemas/endfield/gacha/pool.py
@@ -44,6 +44,8 @@ class EfGachaPoolInfo(BaseModel):
         - pool_id == 'beginner' → 'beginner'
         """
         pid = self.pool_id.lower()
+        if pid.startswith("joint"):
+            return "joint"
         if pid.startswith("special"):
             return "special"
         if pid.startswith("weapon") or pid.startswith("wepon"):
@@ -51,6 +53,11 @@ class EfGachaPoolInfo(BaseModel):
         if pid == "beginner":
             return "beginner"
         return "standard"
+
+    @property
+    def show_spook_stats(self) -> bool:
+        """是否展示六星歪卡统计"""
+        return self.pool_category in {"special", "weapon"} and bool(self.up_six_chars)
 
     @model_validator(mode="before")
     @classmethod

--- a/nonebot_plugin_skland/schemas/endfield/gacha/statistics.py
+++ b/nonebot_plugin_skland/schemas/endfield/gacha/statistics.py
@@ -27,6 +27,8 @@ class EfGroupedGachaRecord(BaseModel):
     """常驻角色池"""
     special_pools: list[EfGachaPoolInfo] = []
     """限定UP角色池"""
+    joint_pools: list[EfGachaPoolInfo] = []
+    """联合寻访角色池"""
     weapon_pools: list[EfGachaPoolInfo] = []
     """武器池"""
 
@@ -34,7 +36,7 @@ class EfGroupedGachaRecord(BaseModel):
     @classmethod
     def sort_pools(cls, values) -> Any:
         if isinstance(values, dict):
-            for key in ("beginner_pools", "standard_pools", "special_pools", "weapon_pools"):
+            for key in ("beginner_pools", "standard_pools", "special_pools", "joint_pools", "weapon_pools"):
                 if key in values and values[key]:
                     values[key] = sorted(
                         values[key],
@@ -47,8 +49,8 @@ class EfGroupedGachaRecord(BaseModel):
 
     @property
     def char_pools(self) -> list[EfGachaPoolInfo]:
-        """所有角色池（beginner + standard + special）"""
-        return self.beginner_pools + self.standard_pools + self.special_pools
+        """所有角色池（beginner + standard + special + joint）"""
+        return self.beginner_pools + self.standard_pools + self.special_pools + self.joint_pools
 
     @property
     def all_pools(self) -> list[EfGachaPoolInfo]:
@@ -70,6 +72,7 @@ class EfGroupedGachaRecord(BaseModel):
         return max(
             len(self.special_pools),
             len(self.weapon_pools),
+            len(self.joint_pools),
             len(self.standard_pools),
             len(self.beginner_pools),
         )
@@ -88,7 +91,13 @@ class EfGroupedGachaRecord(BaseModel):
             切片范围内的 pool_id 集合，若 begin 和 limit 均为 None 则返回全部
         """
         visible: set[str] = set()
-        for pools in (self.special_pools, self.weapon_pools, self.standard_pools, self.beginner_pools):
+        for pools in (
+            self.special_pools,
+            self.weapon_pools,
+            self.joint_pools,
+            self.standard_pools,
+            self.beginner_pools,
+        ):
             for p in pools[begin:limit]:
                 visible.add(p.pool_id)
         return visible
@@ -154,9 +163,45 @@ class EfGroupedGachaRecord(BaseModel):
         return (total_paid - pity_after_last_up) / up_count
 
     @property
+    def joint_total_pulls(self) -> int:
+        """联合寻访总抽数"""
+        return sum(pool.total_pulls for pool in self.joint_pools)
+
+    @property
+    def joint_total_six(self) -> int:
+        """联合寻访总6★数"""
+        return sum(pool.total_six_stars for pool in self.joint_pools)
+
+    @property
+    def joint_pity(self) -> int:
+        """联合寻访当前已垫抽数（保底独立，取最新联合寻访池）"""
+        if not self.joint_pools:
+            return 0
+        latest_pool = max(
+            self.joint_pools,
+            key=lambda p: max((r.gacha_ts for r in p.records), default=0),
+            default=None,
+        )
+        return latest_pool.pity_count if latest_pool else 0
+
+    @property
+    def joint_pity_remaining(self) -> int:
+        """联合寻访距80抽保底还差多少抽"""
+        return max(0, 80 - self.joint_pity)
+
+    @property
+    def joint_six_avg(self) -> float:
+        """联合寻访六星平均抽数"""
+        six_count = self.joint_total_six
+        if six_count == 0:
+            return 0.0
+        total_paid = sum(pool.paid_pulls for pool in self.joint_pools)
+        return (total_paid - self.joint_pity) / six_count
+
+    @property
     def char_total_pulls(self) -> int:
         """角色池总抽数"""
-        return self.beginner_total_pulls + self.standard_total_pulls + self.special_total_pulls
+        return self.beginner_total_pulls + self.standard_total_pulls + self.special_total_pulls + self.joint_total_pulls
 
     @property
     def weapon_total_pulls(self) -> int:

--- a/nonebot_plugin_skland/utils.py
+++ b/nonebot_plugin_skland/utils.py
@@ -509,6 +509,8 @@ def group_gacha_records(records: list[GachaRecord]) -> GroupedGachaRecord:
 def _infer_pool_category(pool_id: str) -> str:
     """根据 pool_id 推导卡池类别"""
     pid = pool_id.lower()
+    if pid.startswith("joint"):
+        return "joint"
     if pid.startswith("special"):
         return "special"
     if pid.startswith("wepon") or pid.startswith("weapon"):
@@ -527,6 +529,7 @@ def group_ef_gacha_records(records: list[GachaRecord]) -> EfGroupedGachaRecord:
     beginner_pools: list[EfGachaPoolInfo] = []
     standard_pools: list[EfGachaPoolInfo] = []
     special_pools: list[EfGachaPoolInfo] = []
+    joint_pools: list[EfGachaPoolInfo] = []
     weapon_pools: list[EfGachaPoolInfo] = []
 
     for pool_id, ts_dict in temp_grouped_records.items():
@@ -562,6 +565,8 @@ def group_ef_gacha_records(records: list[GachaRecord]) -> EfGroupedGachaRecord:
             beginner_pools.append(pool_info)
         elif category == "special":
             special_pools.append(pool_info)
+        elif category == "joint":
+            joint_pools.append(pool_info)
         elif category == "weapon":
             weapon_pools.append(pool_info)
         else:
@@ -571,6 +576,7 @@ def group_ef_gacha_records(records: list[GachaRecord]) -> EfGroupedGachaRecord:
         beginner_pools=beginner_pools,
         standard_pools=standard_pools,
         special_pools=special_pools,
+        joint_pools=joint_pools,
         weapon_pools=weapon_pools,
     )
 

--- a/tests/test_ef_gacha_joint_pool.py
+++ b/tests/test_ef_gacha_joint_pool.py
@@ -104,6 +104,38 @@ def test_group_ef_gacha_records_routes_joint_pool_separately(app):
     )
 
 
+def test_visible_pool_ids_include_joint_pools_and_respect_slicing(app):
+    from nonebot_plugin_skland.utils import group_ef_gacha_records
+
+    grouped = group_ef_gacha_records(
+        [
+            make_record(pool_id="joint_1_2_2", gacha_ts=100),
+            make_record(pool_id="joint_3_4_5", gacha_ts=300),
+            make_record(pool_id="special_1_2_1", gacha_ts=250),
+            make_record(pool_id="weapon_1_2_1", gacha_ts=240),
+            make_record(pool_id="standard", gacha_ts=230),
+            make_record(pool_id="beginner", gacha_ts=220),
+        ]
+    )
+
+    assert grouped.get_visible_pool_ids() == {
+        "joint_1_2_2",
+        "joint_3_4_5",
+        "special_1_2_1",
+        "weapon_1_2_1",
+        "standard",
+        "beginner",
+    }
+    assert grouped.get_visible_pool_ids(0, 1) == {
+        "joint_3_4_5",
+        "special_1_2_1",
+        "weapon_1_2_1",
+        "standard",
+        "beginner",
+    }
+    assert grouped.get_visible_pool_ids(1, 2) == {"joint_1_2_2"}
+
+
 def test_joint_statistics_use_only_six_star_count_and_six_average(app):
     from nonebot_plugin_skland.utils import group_ef_gacha_records
 
@@ -121,6 +153,65 @@ def test_joint_statistics_use_only_six_star_count_and_six_average(app):
     assert grouped.joint_pity_remaining == 78
     assert grouped.joint_six_avg == 1.0
     assert grouped.char_total_pulls == 3
+
+
+def test_joint_six_avg_is_zero_without_six_star_pulls(app):
+    from nonebot_plugin_skland.utils import group_ef_gacha_records
+
+    grouped = group_ef_gacha_records(
+        [
+            make_record(char_id="chr_0019_karin", char_name="秋栗", rarity=4, gacha_ts=200, pos=1),
+            make_record(char_id="chr_0004_pelica", char_name="佩丽卡", rarity=5, gacha_ts=201, pos=2),
+            make_record(char_id="chr_0020_meurs", char_name="卡契尔", rarity=4, gacha_ts=202, pos=3),
+        ]
+    )
+
+    assert grouped.joint_total_six == 0
+    assert grouped.joint_pity == 3
+    assert grouped.joint_pity_remaining == 77
+    assert grouped.joint_six_avg == 0.0
+
+
+def test_joint_current_pity_uses_latest_joint_pool(app):
+    from nonebot_plugin_skland.utils import group_ef_gacha_records
+
+    grouped = group_ef_gacha_records(
+        [
+            make_record(pool_id="joint_1_2_2", rarity=6, gacha_ts=100, pos=1),
+            make_record(
+                pool_id="joint_1_2_2",
+                char_id="chr_0019_karin",
+                char_name="秋栗",
+                rarity=4,
+                gacha_ts=101,
+                pos=2,
+            ),
+            make_record(pool_id="joint_3_4_5", rarity=6, gacha_ts=200, pos=1),
+            make_record(
+                pool_id="joint_3_4_5",
+                char_id="chr_0019_karin",
+                char_name="秋栗",
+                rarity=4,
+                gacha_ts=201,
+                pos=2,
+            ),
+            make_record(
+                pool_id="joint_3_4_5",
+                char_id="chr_0004_pelica",
+                char_name="佩丽卡",
+                rarity=5,
+                gacha_ts=202,
+                pos=3,
+            ),
+        ]
+    )
+
+    assert {pool.pool_id for pool in grouped.joint_pools} == {"joint_1_2_2", "joint_3_4_5"}
+    assert grouped.joint_total_pulls == 5
+    assert grouped.joint_total_six == 2
+    assert grouped.joint_pity == 2
+    assert grouped.joint_pity_remaining == 78
+    assert grouped.joint_six_avg == 1.5
 
 
 def test_joint_pool_type_is_fetched_during_update(app):
@@ -170,13 +261,15 @@ def test_joint_pool_does_not_show_spook_stats(app):
 
 def test_ef_gacha_viewport_expands_when_joint_pools_exist(app):
     from nonebot_plugin_skland.utils import group_ef_gacha_records
-    from nonebot_plugin_skland.render import get_ef_gacha_viewport_width
+    from nonebot_plugin_skland.render import get_ef_gacha_min_width, get_ef_gacha_viewport_width
 
     standard_grouped = group_ef_gacha_records([make_record(pool_id="standard", rarity=4)])
     joint_grouped = group_ef_gacha_records([make_record()])
 
-    assert get_ef_gacha_viewport_width(standard_grouped) == 800
-    assert get_ef_gacha_viewport_width(joint_grouped) == 1020
+    assert get_ef_gacha_min_width(standard_grouped) == 680
+    assert get_ef_gacha_min_width(joint_grouped) == 900
+    assert get_ef_gacha_viewport_width(standard_grouped) == get_ef_gacha_min_width(standard_grouped) + 120
+    assert get_ef_gacha_viewport_width(joint_grouped) == get_ef_gacha_min_width(joint_grouped) + 120
 
 
 def test_joint_pool_keeps_separate_column_with_dynamic_width(app):
@@ -192,7 +285,7 @@ def test_joint_pool_keeps_separate_column_with_dynamic_width(app):
     template = template_path.read_text(encoding="utf-8")
 
     assert 'ef_pool_column(record.joint_pools, "联合寻访", "#c084fc"' in template
-    assert "{{ 900 if record.joint_pools else 680 }}px" in template
+    assert "{{ ef_gacha_min_width }}px" in template
 
 
 def test_pool_header_renders_up_chars_as_avatars(app):

--- a/tests/test_ef_gacha_joint_pool.py
+++ b/tests/test_ef_gacha_joint_pool.py
@@ -1,0 +1,212 @@
+def test_extra_pool_uses_all_rarity_six_as_up_chars(app):
+    from nonebot_plugin_skland.schemas.endfield.gacha.base import EfGachaContentChar, EfGachaContentPool
+
+    pool = EfGachaContentPool(
+        pool_gacha_type="char",
+        pool_type="extra",
+        up6_name="莱万汀",
+        all=[
+            EfGachaContentChar(id="chr_0016_laevat", name="莱万汀", rarity=6),
+            EfGachaContentChar(id="chr_0013_aglina", name="洁尔佩塔", rarity=6),
+            EfGachaContentChar(id="chr_0025_ardelia", name="艾尔黛拉", rarity=6),
+            EfGachaContentChar(id="chr_0029_pograni", name="骏卫", rarity=6),
+            EfGachaContentChar(id="chr_0004_pelica", name="佩丽卡", rarity=5),
+        ],
+    )
+
+    assert pool.up_six_char_ids == [
+        "chr_0016_laevat",
+        "chr_0013_aglina",
+        "chr_0025_ardelia",
+        "chr_0029_pograni",
+    ]
+    assert pool.up_six_display_name == "莱万汀 / 洁尔佩塔 / 艾尔黛拉 / 骏卫"
+
+
+def test_endfield_joint_pool_type_value(app):
+    from nonebot_plugin_skland.schemas.endfield.gacha.base import EndfieldPoolType
+
+    assert EndfieldPoolType.JOINT.value == "E_CharacterGachaPoolType_Joint"
+
+
+def test_joint_pool_id_is_classified_as_joint(app):
+    from nonebot_plugin_skland.utils import _infer_pool_category
+    from nonebot_plugin_skland.schemas.endfield.gacha.pool import EfGachaPoolInfo
+    from nonebot_plugin_skland.schemas.endfield.gacha.base import EfGachaPull, EfGachaGroup
+
+    pool = EfGachaPoolInfo(
+        pool_id="joint_1_2_2",
+        pool_name="辉光庆典",
+        pool_type="char",
+        records=[
+            EfGachaGroup(
+                gacha_ts=100,
+                pulls=[
+                    EfGachaPull(
+                        pool_name="辉光庆典",
+                        item_id="chr_0016_laevat",
+                        item_name="莱万汀",
+                        item_type="char",
+                        rarity=6,
+                        is_new=True,
+                        is_free=False,
+                        seq_id=1,
+                    )
+                ],
+            )
+        ],
+    )
+
+    assert _infer_pool_category("joint_1_2_2") == "joint"
+    assert pool.pool_category == "joint"
+
+
+def make_record(
+    *,
+    pool_id: str = "joint_1_2_2",
+    char_id: str = "chr_0016_laevat",
+    char_name: str = "莱万汀",
+    rarity: int = 6,
+    gacha_ts: int = 100,
+    pos: int = 1,
+    is_free: bool = False,
+):
+    from nonebot_plugin_skland.model import GachaRecord
+
+    return GachaRecord(
+        uid=1,
+        char_pk_id=1,
+        char_uid="endfield-uid",
+        app_code="endfield",
+        item_type="char",
+        pool_id=pool_id,
+        pool_name="辉光庆典",
+        char_id=char_id,
+        char_name=char_name,
+        rarity=rarity,
+        is_new=True,
+        is_free=is_free,
+        gacha_ts=gacha_ts,
+        pos=pos,
+    )
+
+
+def test_group_ef_gacha_records_routes_joint_pool_separately(app):
+    from nonebot_plugin_skland.utils import group_ef_gacha_records
+
+    grouped = group_ef_gacha_records([make_record()])
+
+    assert [p.pool_id for p in grouped.joint_pools] == ["joint_1_2_2"]
+    assert grouped.standard_pools == []
+    assert (
+        grouped.char_pools
+        == grouped.beginner_pools + grouped.standard_pools + grouped.special_pools + grouped.joint_pools
+    )
+
+
+def test_joint_statistics_use_only_six_star_count_and_six_average(app):
+    from nonebot_plugin_skland.utils import group_ef_gacha_records
+
+    grouped = group_ef_gacha_records(
+        [
+            make_record(rarity=6, gacha_ts=100, pos=1),
+            make_record(char_id="chr_0019_karin", char_name="秋栗", rarity=4, gacha_ts=101, pos=2),
+            make_record(char_id="chr_0020_meurs", char_name="卡契尔", rarity=4, gacha_ts=102, pos=3),
+        ]
+    )
+
+    assert grouped.joint_total_pulls == 3
+    assert grouped.joint_total_six == 1
+    assert grouped.joint_pity == 2
+    assert grouped.joint_pity_remaining == 78
+    assert grouped.joint_six_avg == 1.0
+    assert grouped.char_total_pulls == 3
+
+
+def test_joint_pool_type_is_fetched_during_update(app):
+    from nonebot_plugin_skland.commands.endfield.gacha import EF_CHAR_POOL_TYPES
+    from nonebot_plugin_skland.schemas.endfield.gacha.base import EndfieldPoolType
+
+    assert EF_CHAR_POOL_TYPES == [
+        EndfieldPoolType.STANDARD,
+        EndfieldPoolType.SPECIAL,
+        EndfieldPoolType.BEGINNER,
+        EndfieldPoolType.JOINT,
+    ]
+
+
+def test_joint_pool_does_not_show_spook_stats(app):
+    from nonebot_plugin_skland.schemas.endfield.gacha.pool import EfGachaPoolInfo
+    from nonebot_plugin_skland.schemas.endfield.gacha.base import EfGachaPull, EfGachaGroup
+
+    joint_pool = EfGachaPoolInfo(
+        pool_id="joint_1_2_2",
+        pool_name="辉光庆典",
+        pool_type="char",
+        up_six_chars=["chr_0016_laevat", "chr_0013_aglina"],
+        records=[
+            EfGachaGroup(
+                gacha_ts=100,
+                pulls=[
+                    EfGachaPull(
+                        pool_name="辉光庆典",
+                        item_id="chr_0016_laevat",
+                        item_name="莱万汀",
+                        item_type="char",
+                        rarity=6,
+                        is_new=True,
+                        is_free=False,
+                        seq_id=1,
+                    )
+                ],
+            )
+        ],
+    )
+    special_pool = joint_pool.model_copy(update={"pool_id": "special_1_2_1"})
+
+    assert joint_pool.show_spook_stats is False
+    assert special_pool.show_spook_stats is True
+
+
+def test_ef_gacha_viewport_expands_when_joint_pools_exist(app):
+    from nonebot_plugin_skland.utils import group_ef_gacha_records
+    from nonebot_plugin_skland.render import get_ef_gacha_viewport_width
+
+    standard_grouped = group_ef_gacha_records([make_record(pool_id="standard", rarity=4)])
+    joint_grouped = group_ef_gacha_records([make_record()])
+
+    assert get_ef_gacha_viewport_width(standard_grouped) == 800
+    assert get_ef_gacha_viewport_width(joint_grouped) == 1020
+
+
+def test_joint_pool_keeps_separate_column_with_dynamic_width(app):
+    from pathlib import Path
+
+    template_path = (
+        Path(__file__).resolve().parents[1]
+        / "nonebot_plugin_skland"
+        / "resources"
+        / "templates"
+        / "ef_gacha.html.jinja2"
+    )
+    template = template_path.read_text(encoding="utf-8")
+
+    assert 'ef_pool_column(record.joint_pools, "联合寻访", "#c084fc"' in template
+    assert "{{ 900 if record.joint_pools else 680 }}px" in template
+
+
+def test_pool_header_renders_up_chars_as_avatars(app):
+    from pathlib import Path
+
+    template_path = (
+        Path(__file__).resolve().parents[1]
+        / "nonebot_plugin_skland"
+        / "resources"
+        / "templates"
+        / "ef_gacha_macros.html.jinja2"
+    )
+    template = template_path.read_text(encoding="utf-8")
+
+    assert "UP: {{ pool.up6_name }}" not in template
+    assert "{% for up_char_id in pool.up_six_chars %}" in template
+    assert "{{ up_char_id | ef_charId_to_avatarUrl }}" in template


### PR DESCRIPTION
## Summary
- 新增终末地联合寻访卡池类型拉取、分组、统计和独立渲染列
- 支持 extra 池全部 6★ 作为 UP，并将卡池头部 UP 展示改为头像列表
- 联合寻访存在时动态加宽终末地抽卡图，保持原有列宽和类别聚合

## Test plan
- [x] `uv --directory "C:/Proj/nonebot-plugin-skland" run pytest tests/test_ef_gacha_joint_pool.py -v`
- [x] `uv --directory "C:/Proj/nonebot-plugin-skland" run python -m compileall nonebot_plugin_skland`
- [x] `git diff --check`

## Summary by Sourcery

添加对 Endfield 联合卡池的支持，包括数据分组、统计以及渲染更新。

新功能：
- 引入新的 Endfield 联合卡池类型，并将其纳入角色抽卡数据的获取与分组逻辑中。
- 在 Endfield 抽卡记录视图中展示联合卡池统计信息，并新增专用的联合卡池列。
- 以头像列表形式渲染 UP 角色，并将额外卡池中的所有 6★ 视为 UP 目标。

功能优化：
- 在存在联合卡池时动态调整抽卡布局宽度，以保持列宽与分组结构不变。
- 将“歪卡”统计的展示限制在适用的卡池类别中，同时复用通用的卡池表头宏。

测试：
- 添加覆盖联合卡池类型、分组、统计、渲染布局及 UP 头像渲染的全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Endfield joint gacha pools, including data grouping, statistics, and rendering updates.

New Features:
- Introduce a new Endfield joint pool type and include it in character gacha fetching and grouping.
- Display joint gacha statistics and a dedicated joint pool column in the Endfield gacha history view.
- Render UP characters as avatar lists and treat all 6★ in extra pools as UP targets.

Enhancements:
- Adjust gacha layout width dynamically when joint pools are present to preserve column widths and grouping.
- Limit spook statistics display to applicable pool categories while reusing the shared pool header macro.

Tests:
- Add comprehensive tests covering joint pool typing, grouping, statistics, rendering layout, and UP avatar rendering.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加对 Endfield 联合卡池的支持，包括数据分组、统计以及渲染更新。

新功能：
- 引入新的 Endfield 联合卡池类型，并将其纳入角色抽卡数据的获取与分组逻辑中。
- 在 Endfield 抽卡记录视图中展示联合卡池统计信息，并新增专用的联合卡池列。
- 以头像列表形式渲染 UP 角色，并将额外卡池中的所有 6★ 视为 UP 目标。

功能优化：
- 在存在联合卡池时动态调整抽卡布局宽度，以保持列宽与分组结构不变。
- 将“歪卡”统计的展示限制在适用的卡池类别中，同时复用通用的卡池表头宏。

测试：
- 添加覆盖联合卡池类型、分组、统计、渲染布局及 UP 头像渲染的全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Endfield joint gacha pools, including data grouping, statistics, and rendering updates.

New Features:
- Introduce a new Endfield joint pool type and include it in character gacha fetching and grouping.
- Display joint gacha statistics and a dedicated joint pool column in the Endfield gacha history view.
- Render UP characters as avatar lists and treat all 6★ in extra pools as UP targets.

Enhancements:
- Adjust gacha layout width dynamically when joint pools are present to preserve column widths and grouping.
- Limit spook statistics display to applicable pool categories while reusing the shared pool header macro.

Tests:
- Add comprehensive tests covering joint pool typing, grouping, statistics, rendering layout, and UP avatar rendering.

</details>

</details>