### PR TITLE
Refactor: 为所有渲染增加全局超时配置项

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ class Config(BaseModel):
 - `gacha_render_max`: 明日方舟抽卡记录单图渲染卡池上限。
 - `ef_gacha_render_max`: 终末地抽卡记录单图渲染各类别卡池上限。
 - `roster_render_max`: 方舟干员单图渲染数量上限，默认 16。
-- `roster_render_timeout`: 方舟干员传给 htmlrender 的截图超时时间（毫秒）。
+- `render_timeout`: 所有模板传给 htmlrender 的截图超时时间（毫秒），默认 180000。
 - `roster_render_format`: 方舟干员图片格式，支持 `png` / `jpeg`，默认 `jpeg`。
 - `roster_jpeg_quality`: 方舟干员 JPEG 质量，默认 90。
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ _✨ 通过森空岛查询游戏数据 ✨_
 |      `skland__gacha_render_max`      |  否   |    `30`     | 明日方舟抽卡记录单图渲染上限（单位:卡池） |
 |    `skland__ef_gacha_render_max`     |  否   |     `5`     |      终末地抽卡记录单图渲染卡池上限       |
 |     `skland__roster_render_max`     |  否   |    `16`     |      方舟干员单图渲染数量上限       |
-|  `skland__roster_render_timeout`   |  否   |  `180000`   |      方舟干员截图超时时间（毫秒）       |
+|       `skland__render_timeout`       |  否   |  `180000`   |          模板截图超时时间（毫秒）          |
 |   `skland__roster_render_format`   |  否   |  `"jpeg"`  |       方舟干员图片格式：`png` / `jpeg`       |
 |    `skland__roster_jpeg_quality`    |  否   |    `90`     |        方舟干员 JPEG 质量（1-100）         |
 

--- a/nonebot_plugin_skland/config.py
+++ b/nonebot_plugin_skland/config.py
@@ -82,8 +82,8 @@ class ScopedConfig(BaseModel):
     """终末地抽卡记录单图渲染卡池上限"""
     roster_render_max: int = Field(default=16, gt=0)
     """Maximum operators rendered in one roster image."""
-    roster_render_timeout: int = Field(default=180_000, gt=0)
-    """Operator roster screenshot timeout in milliseconds."""
+    render_timeout: int = Field(default=180_000, gt=0)
+    """Template screenshot timeout in milliseconds."""
     roster_render_format: Literal["png", "jpeg"] = "jpeg"
     """Operator roster image format."""
     roster_jpeg_quality: int = Field(default=90, ge=1, le=100)

--- a/nonebot_plugin_skland/render.py
+++ b/nonebot_plugin_skland/render.py
@@ -54,7 +54,7 @@ async def render_operator_roster(
             "base_url": f"file://{TEMPLATES_DIR}",
         },
         device_scale_factor=1.5,
-        screenshot_timeout=config.roster_render_timeout,
+        screenshot_timeout=config.render_timeout,
         readiness="resources",
         type=config.roster_render_format,
         quality=config.roster_jpeg_quality if config.roster_render_format == "jpeg" else None,
@@ -91,6 +91,7 @@ async def render_ark_card(props: ArkCard, bg: str | Url) -> bytes:
             "viewport": {"width": 706, "height": 1160},
             "base_url": f"file://{TEMPLATES_DIR}",
         },
+        screenshot_timeout=config.render_timeout,
     )
 
 
@@ -117,6 +118,7 @@ async def render_rogue_card(props: RogueData, bg: str | Url) -> bytes:
             "base_url": f"file://{TEMPLATES_DIR}",
         },
         device_scale_factor=1.5,
+        screenshot_timeout=config.render_timeout,
     )
 
 
@@ -149,6 +151,7 @@ async def render_rogue_info(props: RogueData, bg: str | Url, id: int, is_favored
             "base_url": f"file://{TEMPLATES_DIR}",
         },
         device_scale_factor=1.5,
+        screenshot_timeout=config.render_timeout,
     )
 
 
@@ -164,6 +167,7 @@ async def render_clue_board(props: Clue):
             "base_url": f"file://{TEMPLATES_DIR}",
         },
         device_scale_factor=1.5,
+        screenshot_timeout=config.render_timeout,
     )
 
 
@@ -189,6 +193,7 @@ async def render_gacha_history(
             "base_url": f"file://{TEMPLATES_DIR}",
         },
         device_scale_factor=1.5,
+        screenshot_timeout=config.render_timeout,
     )
 
 
@@ -232,6 +237,7 @@ async def render_ef_gacha_history(
             "base_url": f"file://{TEMPLATES_DIR}",
         },
         device_scale_factor=1.5,
+        screenshot_timeout=config.render_timeout,
     )
 
 
@@ -308,4 +314,5 @@ async def render_ef_card(props: EndfieldCard, bg: str | Url, show_all: bool = Fa
             "viewport": {"width": 706, "height": 1},
             "base_url": f"file://{TEMPLATES_DIR}",
         },
+        screenshot_timeout=config.render_timeout,
     )

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -233,6 +233,7 @@ async def test_cached_template_delegates_when_disabled(app, mocker, monkeypatch)
 
     assert result == b"image"
     renderer.assert_awaited_once()
+    assert renderer.await_args.kwargs["screenshot_timeout"] == 30_000
     template_renderer.assert_not_awaited()
 
 

--- a/tests/test_operator_roster.py
+++ b/tests/test_operator_roster.py
@@ -745,15 +745,15 @@ def test_box_command_parses_natural_and_advanced_filters(app, operator_catalog):
     [("jpeg", 87, 87), ("png", 87, None)],
 )
 @pytest.mark.asyncio
-async def test_roster_render_uses_props_and_configured_timeout(
+async def test_roster_render_uses_props_and_configured_output(
     app, mocker, monkeypatch, operator_catalog, image_format, jpeg_quality, expected_quality
 ):
     from nonebot_plugin_skland.config import config
     from nonebot_plugin_skland.render import render_operator_roster
     from nonebot_plugin_skland.schemas import OperatorRoster, OperatorRosterQuery
 
-    monkeypatch.setattr(config, "roster_render_timeout", 321_000)
     monkeypatch.setattr(config, "roster_render_format", image_format)
+    monkeypatch.setattr(config, "render_timeout", 321_000)
     monkeypatch.setattr(config, "roster_jpeg_quality", jpeg_quality)
     render = mocker.patch(
         "nonebot_plugin_skland.render.template_to_pic",
@@ -783,6 +783,7 @@ def test_roster_config_defaults(app):
     from nonebot_plugin_skland.config import ScopedConfig
 
     assert ScopedConfig().roster_render_max == 16
+    assert ScopedConfig().render_timeout == 180_000
     assert ScopedConfig().roster_render_format == "jpeg"
     assert ScopedConfig().roster_jpeg_quality == 90
     assert ScopedConfig().ark_card_cache_ttl == 120

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_all_template_renderers_use_configured_timeout(app, mocker, monkeypatch):
+    from nonebot_plugin_skland import render
+    from nonebot_plugin_skland.config import config
+
+    monkeypatch.setattr(config, "render_timeout", 321_000)
+    template_renderer = mocker.patch.object(
+        render,
+        "template_to_pic",
+        new=mocker.AsyncMock(return_value=b"image"),
+    )
+
+    ark_card = SimpleNamespace(
+        status=object(),
+        chars=[],
+        skins=[],
+        building=object(),
+        medal=SimpleNamespace(total=0),
+        assistChars=[],
+        recruit_finished=0,
+        recruit=[],
+        recruit_complete_time=None,
+        campaign=object(),
+        routine=object(),
+        tower=object(),
+        trainee_char=None,
+    )
+    rogue_history = SimpleNamespace(favourRecords=[], records=[])
+    rogue_data = SimpleNamespace(
+        topic_img="",
+        topic="",
+        career=object(),
+        gameUserInfo=object(),
+        history=rogue_history,
+    )
+    ef_gacha = SimpleNamespace(joint_pools=[])
+    ef_card = SimpleNamespace(
+        chars=[],
+        config=SimpleNamespace(charIds=[]),
+        spaceShip=SimpleNamespace(rooms=[]),
+        domain=[],
+        currentTs=None,
+        dungeon=SimpleNamespace(maxTs=None, curStamina=None, maxStamina=None),
+        base=object(),
+        bpSystem=object(),
+        dailyMission=object(),
+        weeklyMission=object(),
+        achieve=object(),
+    )
+
+    await render.render_operator_roster(props=object(), background_image=None)
+    await render.render_ark_card(ark_card, "background.jpg")
+    await render.render_rogue_card(rogue_data, "background.jpg")
+    await render.render_rogue_info(rogue_data, "background.jpg", 1, False)
+    await render.render_clue_board(object())
+    await render.render_gacha_history(object(), object(), object())
+    await render.render_ef_gacha_history(ef_gacha, SimpleNamespace(avatarUrl=""), object())
+    await render.render_ef_card(ef_card, "background.jpg")
+
+    assert template_renderer.await_count == 8
+    assert {call.kwargs["template_name"] for call in template_renderer.await_args_list} == {
+        "operator_roster.html.jinja2",
+        "ark_card.html.jinja2",
+        "rogue.html.jinja2",
+        "rogue_info.html.jinja2",
+        "clue.html.jinja2",
+        "gacha.html.jinja2",
+        "ef_gacha.html.jinja2",
+        "endfield_card.html.jinja2",
+    }
+    assert all(call.kwargs["screenshot_timeout"] == 321_000 for call in template_renderer.await_args_list)


### PR DESCRIPTION
resolve #104

## Summary by Sourcery

引入全局模板渲染超时配置，并将其应用到所有 HTML 模板渲染器中。

新功能：
- 为模板截图操作添加全局 `render_timeout` 配置。

增强改进：
- 用全局 `render_timeout` 替换原先仅用于 roster 的渲染超时设置，统一应用于所有渲染函数。
- 在 `AGENTS.md` 和 `README.md` 中记录新的 `render_timeout` 选项。

测试：
- 添加测试以确保所有模板渲染器都遵守全局 `render_timeout`，并更新现有测试以反映新的默认配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a global template rendering timeout configuration and apply it across all HTML template renderers.

New Features:
- Add a global render_timeout configuration for template screenshot operations.

Enhancements:
- Replace the roster-specific render timeout with the global render_timeout across all rendering functions.
- Document the new render_timeout option in AGENTS.md and README.md.

Tests:
- Add tests to ensure all template renderers honor the global render_timeout and update existing tests to reflect the new configuration default.

</details>